### PR TITLE
Spread messages across all partitions

### DIFF
--- a/library.c
+++ b/library.c
@@ -25,8 +25,6 @@ void kafka_err_cb (rd_kafka_t *rk, int err, const char *reason, void *opaque) {
     openlog("phpkafka", 0, LOG_USER);
     syslog(LOG_INFO, "phpkafka - ERROR CALLBACK: %s: %s: %s\n", 
             rd_kafka_name(rk), rd_kafka_err2str(err), reason);
-    
-    kafka_stop(err);
 }
 
 void kafka_msg_delivered (rd_kafka_t *rk,


### PR DESCRIPTION
Most kafka instances in production have multiple partitions.  For best performance the messages should be spread across all partitions.

Use rdkafka's option for automatic partitioning using the topic's partitioner function.
