### PR TITLE
Suggested fix for issue #7: Kafka::consume exits if set_partition was not called

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,8 @@ Examples:
 // Produce a message
 $kafka = new Kafka("localhost:9092");
 $kafka->produce("topic_name", "message content");
+$partition = 1;//specify the partition somehow
+//the partition needs to be set, or the consume method will cause a fatal error (C code: exit(1);)
+$kafka->set_partition($partition);
 $kafka->consume("topic_name", 1172556);
 ```

--- a/kafka.c
+++ b/kafka.c
@@ -42,6 +42,14 @@ void kafka_connect(char *brokers)
     kafka_setup(brokers);
 }
 
+//return 1 if rd is not NULL
+int kafka_is_connected( void )
+{
+    if (rk == NULL)
+        return 0;
+    return 1;
+}
+
 void kafka_set_partition(int partition_selected)
 {
     partition = partition_selected;

--- a/kafka.c
+++ b/kafka.c
@@ -278,16 +278,17 @@ void kafka_consume(zval* return_value, char* topic, char* offset, int item_count
 
       rd_kafka_message_t *rkmessage_return;
       rkmessage_return = msg_consume(rkmessage, NULL);
-      if (rkmessage_return == NULL) {
-          //msg_consume returned NULL indicating an error
-          //use rkmessage->err to produce notice?, for now:
-          rd_kafka_message_destroy(rkmessage);
-          break;
+      if (rkmessage_return != NULL) {
+          if (rkmessage_return->len > 0) {
+              //ensure there is a payload
+              char payload[(int) rkmessage_return->len];
+              sprintf(payload, "%.s", (int) rkmessage_return->len, (char *) rkmessage_return->payload);
+              add_index_string(return_value, (unsigned int) rkmessage_return->len, payload, 1);
+          } else {
+              //add empty value
+              add_index_string(return_value, (unsigned int) rkmessage_return->len, "", 1);
+          }
       }
-      char payload[(int)rkmessage_return->len];
-      sprintf(payload, "%.*s", (int)rkmessage_return->len, (char *)rkmessage_return->payload);
-      add_next_index_stringl(return_value, payload, (unsigned int) rkmessage_return->len, 1);
-
       /* Return message to rdkafka */
       rd_kafka_message_destroy(rkmessage);
     }

--- a/kafka.c
+++ b/kafka.c
@@ -82,7 +82,8 @@ void kafka_destroy()
 {
     if(rk != NULL) {
         rd_kafka_destroy(rk);
-        rd_kafka_wait_destroyed(1000);
+        //this wait is blocking PHP
+        //rd_kafka_wait_destroyed(1000);
         rk = NULL;
     }
 }
@@ -262,7 +263,7 @@ void kafka_consume(zval* return_value, char* topic, char* offset, int item_count
         syslog(LOG_INFO, "phpkafka - read_counter: %d", read_counter);
         if (read_counter == -1) {
           run = 0;
-          continue;
+          break;//do not continue, will result in UB => rkmessage is invalid pointer!
         }
       }
 

--- a/kafka.c
+++ b/kafka.c
@@ -25,7 +25,6 @@
 #include <syslog.h>
 #include <sys/time.h>
 #include <errno.h>
-#include <syslog.h>
 #include <time.h>
 #include "kafka.h"
 #include "librdkafka/rdkafka.h"

--- a/kafka.c
+++ b/kafka.c
@@ -279,7 +279,7 @@ void kafka_consume(zval* return_value, char* topic, char* offset, int item_count
       rkmessage_return = msg_consume(rkmessage, NULL);
       char payload[(int)rkmessage_return->len];
       sprintf(payload, "%.*s", (int)rkmessage_return->len, (char *)rkmessage_return->payload);
-      add_index_string(return_value, (int)rkmessage_return->offset, payload, 1);
+      add_next_index_stringl(return_value, payload, (unsigned int) rkmessage_return->len, 1);
 
       /* Return message to rdkafka */
       rd_kafka_message_destroy(rkmessage);

--- a/kafka.c
+++ b/kafka.c
@@ -16,7 +16,7 @@
 #include <php.h>
 #include "kafka.h"
 #include <php_kafka.h>
-
+#include <inttypes.h>
 #include <ctype.h>
 #include <signal.h>
 #include <string.h>
@@ -28,9 +28,72 @@
 #include <time.h>
 #include "kafka.h"
 #include "librdkafka/rdkafka.h"
+typedef struct rd_kafka_topic_conf_s {
+    int     required_acks;
+        int     enforce_isr_cnt;
+    int32_t request_timeout_ms;
+    int     message_timeout_ms;
 
+    int32_t (*partitioner) (const rd_kafka_topic_t *rkt,
+                const void *keydata, size_t keylen,
+                int32_t partition_cnt,
+                void *rkt_opaque,
+                void *msg_opaque);
+
+        int     produce_offset_report;
+
+        char   *group_id_str;
+        void *group_id;    /* Consumer group id in protocol format */
+
+    int     auto_commit;
+    int     auto_commit_interval_ms;
+    int     auto_offset_reset;
+    char   *offset_store_path;
+    int     offset_store_sync_interval_ms;
+        enum {
+                RD_KAFKA_OFFSET_METHOD_FILE,
+                RD_KAFKA_OFFSET_METHOD_BROKER,
+        } offset_store_method;
+
+    /* Application provided opaque pointer (this is rkt_opaque) */
+    void   *opaque;
+} rd_kafka_topic_conf_t;
+struct rd_kafka_topic_s {
+    struct {
+        struct rd_kafka_topic_s *tqe_next;
+        struct rd_kafka_topic_s **tqe_prev;
+    };
+
+    int                rkt_refcnt;
+
+    pthread_rwlock_t   rkt_lock;
+    void *rkt_topic;
+    struct rd_kafka_toppar_s  *rkt_ua;  /* unassigned partition */
+    struct rd_kafka_toppar_s **rkt_p;
+    int32_t            rkt_partition_cnt;
+    struct {
+        void * tqh_first;
+        void * tqh_last;
+    } rkt_desp;
+    uint64_t             rkt_ts_metadata; /* Timestamp of last metadata
+                         * update for this topic. */
+
+    enum {
+        RD_KAFKA_TOPIC_S_UNKNOWN,   /* No cluster information yet */
+        RD_KAFKA_TOPIC_S_EXISTS,    /* Topic exists in cluster */
+        RD_KAFKA_TOPIC_S_NOTEXISTS, /* Topic is not known in cluster */
+    } rkt_state;
+
+        int                rkt_flags;
+#define RD_KAFKA_TOPIC_F_LEADER_QUERY  0x1 /* There is an outstanding
+                                            * leader query for this topic */
+    rd_kafka_t* rkt_rk;
+
+    rd_kafka_topic_conf_t rkt_conf;
+};
 static int run = 1;
 static rd_kafka_t *rk;
+static rd_kafka_type_t rk_type;
 static int exit_eof = 1; //Exit consumer when last message
 char *brokers = "localhost:9092";
 int64_t start_offset = 0;
@@ -96,7 +159,38 @@ void kafka_destroy()
     }
 }
 
-int kafka_produce(char* topic, char* msg, int msg_len)
+static void kafka_init( rd_kafka_type_t type )
+{
+    if (rk_type != type) {
+        kafka_destroy();
+    }
+    if (rk == NULL)
+    {
+        char errstr[512];
+        rd_kafka_conf_t *conf = rd_kafka_conf_new();
+        if (!(rk = rd_kafka_new(type, conf, errstr, sizeof(errstr)))) {
+            openlog("phpkafka", 0, LOG_USER);
+            syslog(LOG_INFO, "phpkafka - failed to create new producer: %s", errstr);
+            exit(1);
+        }
+        /* Add brokers */
+        if (rd_kafka_brokers_add(rk, brokers) == 0) {
+            openlog("phpkafka", 0, LOG_USER);
+            syslog(LOG_INFO, "php kafka - No valid brokers specified");
+            exit(1);
+        }
+        /* Set up a message delivery report callback.
+         * It will be called once for each message, either on successful
+         * delivery to broker, or upon failure to deliver to broker. */
+        rd_kafka_conf_set_dr_cb(conf, kafka_msg_delivered);
+        rd_kafka_conf_set_error_cb(conf, kafka_err_cb);
+
+        openlog("phpkafka", 0, LOG_USER);
+        syslog(LOG_INFO, "phpkafka - using: %s", brokers);
+    }
+}
+
+void kafka_produce(char* topic, char* msg, int msg_len)
 {
 
     signal(SIGINT, kafka_stop);
@@ -107,35 +201,7 @@ int kafka_produce(char* topic, char* msg, int msg_len)
 
     rd_kafka_topic_conf_t *topic_conf;
 
-    if(rk == NULL) {
-        char errstr[512];
-        rd_kafka_conf_t *conf;
-
-        /* Kafka configuration */
-        conf = rd_kafka_conf_new();
-
-        if (!(rk = rd_kafka_new(RD_KAFKA_PRODUCER, conf, errstr, sizeof(errstr)))) {
-                openlog("phpkafka", 0, LOG_USER);
-                syslog(LOG_INFO, "phpkafka - failed to create new producer: %s", errstr);
-                exit(1);
-        }
-
-        /* Add brokers */
-        if (rd_kafka_brokers_add(rk, brokers) == 0) {
-                openlog("phpkafka", 0, LOG_USER);
-                syslog(LOG_INFO, "php kafka - No valid brokers specified");
-                exit(1);
-        }
-
-        /* Set up a message delivery report callback.
-         * It will be called once for each message, either on successful
-         * delivery to broker, or upon failure to deliver to broker. */
-        rd_kafka_conf_set_dr_cb(conf, kafka_msg_delivered);
-        rd_kafka_conf_set_error_cb(conf, kafka_err_cb);
-
-        openlog("phpkafka", 0, LOG_USER);
-        syslog(LOG_INFO, "phpkafka - using: %s", brokers);
-    }
+    kafka_init(RD_KAFKA_PRODUCER);
 
     /* Topic configuration */
     topic_conf = rd_kafka_topic_conf_new();
@@ -160,7 +226,6 @@ int kafka_produce(char* topic, char* msg, int msg_len)
           rd_kafka_err2str(
             rd_kafka_errno2err(errno)));
       rd_kafka_poll(rk, 0);
-      partition = -1;
     }
 
     /* Poll to handle delivery reports */
@@ -171,7 +236,6 @@ int kafka_produce(char* topic, char* msg, int msg_len)
       rd_kafka_poll(rk, 100);
 
     rd_kafka_topic_destroy(rkt);
-    return partition;
 }
 
 static rd_kafka_message_t *msg_consume(rd_kafka_message_t *rkmessage,
@@ -203,6 +267,26 @@ static rd_kafka_message_t *msg_consume(rd_kafka_message_t *rkmessage,
   return rkmessage;
 }
 
+//get the available partitions for a given topic
+void kafka_get_partitions(zval *return_value, char *topic)
+{
+    rd_kafka_topic_t *rkt;
+    rd_kafka_topic_conf_t *conf;
+    int i;//C89 compliant
+    //connect if required
+    //preserve current type
+    kafka_init(rk_type);
+    /* Topic configuration */
+    conf = rd_kafka_topic_conf_new();
+
+    /* Create topic */
+    rkt = rd_kafka_topic_new(rk, topic, conf);
+
+    for (i=0;i < (rkt)->rkt_partition_cnt;++i) {
+        add_next_index_long(return_value, i);
+    }
+}
+
 void kafka_consume(zval* return_value, char* topic, char* offset, int item_count)
 {
 
@@ -221,25 +305,7 @@ void kafka_consume(zval* return_value, char* topic, char* offset, int item_count
 
     rd_kafka_topic_t *rkt;
 
-    char errstr[512];
-    rd_kafka_conf_t *conf;
-
-    /* Kafka configuration */
-    conf = rd_kafka_conf_new();
-
-    /* Create Kafka handle */
-    if (!(rk = rd_kafka_new(RD_KAFKA_CONSUMER, conf, errstr, sizeof(errstr)))) {
-                  openlog("phpkafka", 0, LOG_USER);
-                  syslog(LOG_INFO, "phpkafka - failed to create new consumer: %s", errstr);
-                  exit(1);
-    }
-
-    /* Add brokers */
-    if (rd_kafka_brokers_add(rk, brokers) == 0) {
-            openlog("phpkafka", 0, LOG_USER);
-            syslog(LOG_INFO, "php kafka - No valid brokers specified");
-            exit(1);
-    }
+    kafka_init(RD_KAFKA_CONSUMER);
 
     rd_kafka_topic_conf_t *topic_conf;
 

--- a/kafka.c
+++ b/kafka.c
@@ -239,7 +239,7 @@ void kafka_consume(zval* return_value, char* topic, char* offset, int item_count
     rkt = rd_kafka_topic_new(rk, topic, topic_conf);
 
     openlog("phpkafka", 0, LOG_USER);
-    syslog(LOG_INFO, "phpkafka - start_offset: %d and offset passed: %d", start_offset, offset);
+    syslog(LOG_INFO, "phpkafka - start_offset: %"PRId64" and offset passed: %s", start_offset, offset);
 
     /* Start consuming */
     if (rd_kafka_consume_start(rkt, partition, start_offset) == -1) {

--- a/kafka.c
+++ b/kafka.c
@@ -279,14 +279,15 @@ void kafka_consume(zval* return_value, char* topic, char* offset, int item_count
       rd_kafka_message_t *rkmessage_return;
       rkmessage_return = msg_consume(rkmessage, NULL);
       if (rkmessage_return != NULL) {
-          if (rkmessage_return->len > 0) {
+          if ((int) rkmessage_return->len > 0) {
               //ensure there is a payload
               char payload[(int) rkmessage_return->len];
-              sprintf(payload, "%.s", (int) rkmessage_return->len, (char *) rkmessage_return->payload);
-              add_index_string(return_value, (unsigned int) rkmessage_return->len, payload, 1);
+              sprintf(payload, "%.*s", (int) rkmessage_return->len, (char *) rkmessage_return->payload);
+              add_index_string(return_value, (int) rkmessage_return->offset, payload, 1);
           } else {
               //add empty value
-              add_index_string(return_value, (unsigned int) rkmessage_return->len, "", 1);
+              char payload[1] = "";//empty string
+              add_index_string(return_value, (int) rkmessage_return->offset, payload, 1);
           }
       }
       /* Return message to rdkafka */

--- a/kafka.c
+++ b/kafka.c
@@ -87,7 +87,7 @@ void kafka_destroy()
     }
 }
 
-void kafka_produce(char* topic, char* msg, int msg_len)
+int kafka_produce(char* topic, char* msg, int msg_len)
 {
 
     signal(SIGINT, kafka_stop);
@@ -151,6 +151,7 @@ void kafka_produce(char* topic, char* msg, int msg_len)
           rd_kafka_err2str(
             rd_kafka_errno2err(errno)));
       rd_kafka_poll(rk, 0);
+      partition = -1;
     }
 
     /* Poll to handle delivery reports */
@@ -161,6 +162,7 @@ void kafka_produce(char* topic, char* msg, int msg_len)
       rd_kafka_poll(rk, 100);
 
     rd_kafka_topic_destroy(rkt);
+    return partition;
 }
 
 static rd_kafka_message_t *msg_consume(rd_kafka_message_t *rkmessage,

--- a/kafka.c
+++ b/kafka.c
@@ -83,7 +83,8 @@ void kafka_destroy()
     if(rk != NULL) {
         rd_kafka_destroy(rk);
         //this wait is blocking PHP
-        //rd_kafka_wait_destroyed(1000);
+        //not calling it will yield segfault, though
+        rd_kafka_wait_destroyed(5);
         rk = NULL;
     }
 }

--- a/kafka.c
+++ b/kafka.c
@@ -263,7 +263,7 @@ void kafka_consume(zval* return_value, char* topic, char* offset, int item_count
         syslog(LOG_INFO, "phpkafka - read_counter: %d", read_counter);
         if (read_counter == -1) {
           run = 0;
-          break;//do not continue, will result in UB => rkmessage is invalid pointer!
+          continue;//so continue, or we'll get a segfault
         }
       }
 

--- a/kafka.h
+++ b/kafka.h
@@ -20,6 +20,7 @@
 void kafka_setup(char *brokers);
 void kafka_set_partition(int partition);
 int kafka_produce(char* topic, char* msg, int msg_len);
+int kafka_is_connected( void );
 void kafka_consume(zval* return_value, char* topic, char* offset, int item_count);
 void kafka_destroy();
 

--- a/kafka.h
+++ b/kafka.h
@@ -19,7 +19,7 @@
 
 void kafka_setup(char *brokers);
 void kafka_set_partition(int partition);
-void kafka_produce(char* topic, char* msg, int msg_len);
+int kafka_produce(char* topic, char* msg, int msg_len);
 void kafka_consume(zval* return_value, char* topic, char* offset, int item_count);
 void kafka_destroy();
 

--- a/kafka.h
+++ b/kafka.h
@@ -19,9 +19,10 @@
 
 void kafka_setup(char *brokers);
 void kafka_set_partition(int partition);
-int kafka_produce(char* topic, char* msg, int msg_len);
+void kafka_produce(char* topic, char* msg, int msg_len);
 int kafka_is_connected( void );
 void kafka_consume(zval* return_value, char* topic, char* offset, int item_count);
+void kafka_get_partitions(zval *return_value, char *topic);
 void kafka_destroy();
 
 #endif

--- a/php_kafka.c
+++ b/php_kafka.c
@@ -101,7 +101,8 @@ PHP_METHOD(Kafka, set_partition)
 
 PHP_METHOD(Kafka, produce)
 {
-    zval *object = getThis();
+    zval *object = getThis(),
+        *partition;
     char *topic;
     char *msg;
     int topic_len;

--- a/php_kafka.c
+++ b/php_kafka.c
@@ -70,6 +70,14 @@ PHP_MINIT_FUNCTION(kafka)
     INIT_CLASS_ENTRY(ce, "Kafka", kafka_functions);
     kafka_ce = zend_register_internal_class(&ce TSRMLS_CC);
     zend_declare_property_null(kafka_ce, "partition", sizeof("partition") -1, ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_class_constant_stringl(
+        kafka_ce, "OFFSET_BEGIN", sizeof("OFFSET_BEGIN") -1,
+        "beginning", sizeof("beginning")-1
+    );
+    zend_declare_class_constant_stringl(
+        kafka_ce, "OFFSET_END", sizeof("OFFSET_END")-1,
+        "end", sizeof("end")
+    );
     return SUCCESS;
 }
 PHP_RSHUTDOWN_FUNCTION(kafka) { return SUCCESS; }

--- a/php_kafka.c
+++ b/php_kafka.c
@@ -130,9 +130,12 @@ PHP_METHOD(Kafka, consume)
 
     partition = zend_read_property(kafka_ce, object, "partition", sizeof("partition") -1, 0 TSRMLS_CC);
     if (Z_TYPE_P(partition) == IS_NULL) {
-        //TODO: throw exception, trigger error, fallback to default (1)? partition...
-        RETURN_FALSE;
-        return;
+        //TODO: throw exception, trigger error, fallback to default (0) partition...
+        //for now, default to 0
+        kafka_set_partition(0);
+        ZVAL_LONG(partition, 0);
+        //update property value ->
+        zend_update_property(kafka_ce, object, "partition", sizeof("partition") -1, partition TSRMLS_CC);
     }
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|sl",
             &topic, &topic_len,

--- a/php_kafka.c
+++ b/php_kafka.c
@@ -30,6 +30,7 @@ zend_class_entry *kafka_ce;
 /* each method can have its own parameters and visibility */
 static zend_function_entry kafka_functions[] = {
     PHP_ME(Kafka, __construct, NULL, ZEND_ACC_CTOR | ZEND_ACC_PUBLIC)
+    PHP_ME(Kafka, __destruct, NULL, ZEND_ACC_DTOR | ZEND_ACC_PUBLIC)
     PHP_ME(Kafka, set_partition, NULL, ZEND_ACC_PUBLIC)
     PHP_ME(Kafka, produce, NULL, ZEND_ACC_PUBLIC)
     PHP_ME(Kafka, consume, NULL, ZEND_ACC_PUBLIC)
@@ -87,6 +88,13 @@ PHP_METHOD(Kafka, __construct)
     }
 
     kafka_connect(brokers);
+}
+
+PHP_METHOD(Kafka, __destruct)
+{
+    if (kafka_is_connected()) {
+        kafka_destroy();
+    }
 }
 
 PHP_METHOD(Kafka, set_partition)

--- a/php_kafka.c
+++ b/php_kafka.c
@@ -34,6 +34,7 @@ static zend_function_entry kafka_functions[] = {
     PHP_ME(Kafka, set_partition, NULL, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED)
     PHP_ME(Kafka, setPartition, NULL, ZEND_ACC_PUBLIC)
     PHP_ME(Kafka, disconnect, NULL, ZEND_ACC_PUBLIC)
+    PHP_ME(Kafka, isConnected, NULL, ZEND_ACC_PUBLIC)
     PHP_ME(Kafka, produce, NULL, ZEND_ACC_PUBLIC)
     PHP_ME(Kafka, consume, NULL, ZEND_ACC_PUBLIC)
     {NULL,NULL,NULL} /* Marks the end of function entries */
@@ -69,6 +70,8 @@ PHP_MINIT_FUNCTION(kafka)
     zend_class_entry ce;
     INIT_CLASS_ENTRY(ce, "Kafka", kafka_functions);
     kafka_ce = zend_register_internal_class(&ce TSRMLS_CC);
+    //do not allow people to extend this class, make it final
+    kafka_ce->ce_flags |= ZEND_ACC_FINAL_CLASS;
     zend_declare_property_null(kafka_ce, "partition", sizeof("partition") -1, ZEND_ACC_PRIVATE TSRMLS_CC);
     zend_declare_class_constant_stringl(
         kafka_ce, "OFFSET_BEGIN", sizeof("OFFSET_BEGIN") -1,
@@ -100,11 +103,17 @@ PHP_METHOD(Kafka, __construct)
     kafka_connect(brokers);
 }
 
-PHP_METHOD(Kafka, __destruct)
+PHP_METHOD(Kafka, isConnected)
 {
     if (kafka_is_connected()) {
-        kafka_destroy();
+        RETURN_TRUE;
     }
+    RETURN_FALSE;
+}
+
+PHP_METHOD(Kafka, __destruct)
+{
+    kafka_destroy();
 }
 
 PHP_METHOD(Kafka, set_partition)

--- a/php_kafka.c
+++ b/php_kafka.c
@@ -33,6 +33,7 @@ static zend_function_entry kafka_functions[] = {
     PHP_ME(Kafka, __destruct, NULL, ZEND_ACC_DTOR | ZEND_ACC_PUBLIC)
     PHP_ME(Kafka, set_partition, NULL, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED)
     PHP_ME(Kafka, setPartition, NULL, ZEND_ACC_PUBLIC)
+    PHP_ME(Kafka, getPartitionsForTopic, NULL, ZEND_ACC_PUBLIC)
     PHP_ME(Kafka, disconnect, NULL, ZEND_ACC_PUBLIC)
     PHP_ME(Kafka, isConnected, NULL, ZEND_ACC_PUBLIC)
     PHP_ME(Kafka, produce, NULL, ZEND_ACC_PUBLIC)
@@ -168,6 +169,22 @@ PHP_METHOD(Kafka, setPartition)
 }
 /* }}} end Kafka::setPartition */
 
+/* {{{ proto array Kafka::getPartitionsForTopic( string $topic )
+    Get an array of available partitions for a given topic
+*/
+PHP_METHOD(Kafka, getPartitionsForTopic)
+{
+    char *topic = NULL;
+    int topic_len = 0;
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s",
+            &topic, &topic_len) == FAILURE) {
+        return;
+    }
+    array_init(return_value);
+    kafka_get_partitions(return_value, topic);
+}
+/* }}} end Kafka::getPartitionsForTopic */
+
 /* {{{ proto bool Kafka::disconnect( void );
     Disconnects kafka, returns false if disconnect failed
     Warning: producing a new message will reconnect to the initial brokers
@@ -182,7 +199,7 @@ PHP_METHOD(Kafka, disconnect)
 }
 /* }}} end Kafka::disconnect */
 
-/* {{{ proto mixed Kafka::produce( string $topic, string $message);
+/* {{{ proto void Kafka::produce( string $topic, string $message);
     Produce a message, returns int (partition used to produce)
     or false if something went wrong
 */
@@ -194,7 +211,6 @@ PHP_METHOD(Kafka, produce)
     char *msg;
     int topic_len;
     int msg_len;
-    int prod_val;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss",
             &topic, &topic_len,
@@ -202,11 +218,7 @@ PHP_METHOD(Kafka, produce)
         return;
     }
 
-    prod_val = kafka_produce(topic, msg, msg_len);
-    if (prod_val == -1) {
-        RETURN_FALSE;
-    }
-    RETURN_LONG(prod_val);
+    kafka_produce(topic, msg, msg_len);
 }
 /* }}} end Kafka::produce */
 

--- a/php_kafka.c
+++ b/php_kafka.c
@@ -113,6 +113,15 @@ PHP_METHOD(Kafka, produce)
         return;
     }
 
+    partition = zend_read_property(kafka_ce, object, "partition", sizeof("partition") -1, 0 TSRMLS_CC);
+    if (Z_TYPE_P(partition) == IS_NULL) {
+        //set partition explicitly
+        kafka_set_partition(0);
+        ZVAL_LONG(partition, 0);
+        //update property value ->
+        zend_update_property(kafka_ce, object, "partition", sizeof("partition") -1, partition TSRMLS_CC);
+    }
+
     kafka_produce(topic, msg, msg_len);
 
     RETURN_TRUE;

--- a/php_kafka.c
+++ b/php_kafka.c
@@ -87,6 +87,9 @@ PHP_MSHUTDOWN_FUNCTION(kafka) {
     return SUCCESS;
 }
 
+/** {{{ proto void DOMDocument::__construct( string $brokers );
+    Constructor, expects a comma-separated list of brokers to connect to
+*/
 PHP_METHOD(Kafka, __construct)
 {
     char *brokers = "localhost:9092";
@@ -99,7 +102,11 @@ PHP_METHOD(Kafka, __construct)
 
     kafka_connect(brokers);
 }
+/* }}} end Kafka::__construct */
 
+/* {{{ proto bool Kafka::isConnected( void )
+    returns true if kafka connection is active, fals if not
+*/
 PHP_METHOD(Kafka, isConnected)
 {
     if (kafka_is_connected()) {
@@ -107,12 +114,22 @@ PHP_METHOD(Kafka, isConnected)
     }
     RETURN_FALSE;
 }
+/* }}} end bool Kafka::isConnected */
 
+/* {{{ proto void Kafka::__destruct( void )
+    constructor, disconnects kafka
+*/
 PHP_METHOD(Kafka, __destruct)
 {
     kafka_destroy();
 }
+/* }}} end Kafka::__destruct */
 
+/* {{{ proto void Kafka::set_partition( int $partition );
+    Set partition (used by consume method)
+    This method is deprecated, in favour of the more PSR-compliant
+    Kafka::setPartition
+*/
 PHP_METHOD(Kafka, set_partition)
 {
     zval *partition;
@@ -129,8 +146,11 @@ PHP_METHOD(Kafka, set_partition)
     //update partition property, so we can check to see if it's set when consuming
     zend_update_property(kafka_ce, getThis(), "partition", sizeof("partition") -1, partition TSRMLS_CC);
 }
+/* }}} end Kafka::set_partition */
 
-//leave duplicate method for now, set_partition is deprecated
+/* {{{ proto void Kafka::setPartition( int $partition );
+    Set partition to use for Kafka::consume calls
+*/
 PHP_METHOD(Kafka, setPartition)
 {
     zval *partition;
@@ -146,7 +166,12 @@ PHP_METHOD(Kafka, setPartition)
     kafka_set_partition(Z_LVAL_P(partition));
     zend_update_property(kafka_ce, getThis(), "partition", sizeof("partition") -1, partition TSRMLS_CC);
 }
+/* }}} end Kafka::setPartition */
 
+/* {{{ proto bool Kafka::disconnect( void );
+    Disconnects kafka, returns false if disconnect failed
+    Warning: producing a new message will reconnect to the initial brokers
+*/
 PHP_METHOD(Kafka, disconnect)
 {
     kafka_destroy();
@@ -155,7 +180,12 @@ PHP_METHOD(Kafka, disconnect)
     }
     RETURN_TRUE;
 }
+/* }}} end Kafka::disconnect */
 
+/* {{{ proto mixed Kafka::produce( string $topic, string $message);
+    Produce a message, returns int (partition used to produce)
+    or false if something went wrong
+*/
 PHP_METHOD(Kafka, produce)
 {
     zval *object = getThis(),
@@ -178,7 +208,11 @@ PHP_METHOD(Kafka, produce)
     }
     RETURN_LONG(prod_val);
 }
+/* }}} end Kafka::produce */
 
+/* {{{ proto array Kafka::consume( string $topic, [ mixed $offset = 0 [, int $length = 1] ] );
+    Consumes 1 or more ($length) messages from the $offset (default 0)
+*/
 PHP_METHOD(Kafka, consume)
 {
     zval *object = getThis(),
@@ -218,3 +252,4 @@ PHP_METHOD(Kafka, consume)
         RETURN_FALSE;
     }
 }
+/* }}} end Kafka::consume */

--- a/php_kafka.c
+++ b/php_kafka.c
@@ -114,6 +114,7 @@ PHP_METHOD(Kafka, produce)
     char *msg;
     int topic_len;
     int msg_len;
+    int prod_val;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss",
             &topic, &topic_len,
@@ -121,18 +122,11 @@ PHP_METHOD(Kafka, produce)
         return;
     }
 
-    partition = zend_read_property(kafka_ce, object, "partition", sizeof("partition") -1, 0 TSRMLS_CC);
-    if (Z_TYPE_P(partition) == IS_NULL) {
-        //set partition explicitly
-        kafka_set_partition(0);
-        ZVAL_LONG(partition, 0);
-        //update property value ->
-        zend_update_property(kafka_ce, object, "partition", sizeof("partition") -1, partition TSRMLS_CC);
+    prod_val = kafka_produce(topic, msg, msg_len);
+    if (prod_val == -1) {
+        RETURN_FALSE;
     }
-
-    kafka_produce(topic, msg, msg_len);
-
-    RETURN_TRUE;
+    RETURN_LONG(prod_val);
 }
 
 PHP_METHOD(Kafka, consume)

--- a/php_kafka.c
+++ b/php_kafka.c
@@ -21,6 +21,7 @@
 #include <php.h>
 #include <php_kafka.h>
 #include "kafka.h"
+#include "zend_exceptions.h"
 
 /* decalre the class entry */
 zend_class_entry *kafka_ce;
@@ -52,6 +53,13 @@ zend_module_entry kafka_module_entry = {
 ZEND_GET_MODULE(kafka)
 #endif
 
+#ifndef BASE_EXCEPTION
+#if (PHP_MAJOR_VERSION < 5) || ( ( PHP_MAJOR_VERSION == 5 ) && (PHP_MINOR_VERSION < 2) )
+#define BASE_EXCEPTION zend_exception_get_default()
+#else
+#define BASE_EXCEPTION zend_exception_get_default(TSRMLS_C)
+#endif
+#endif
 
 PHP_MINIT_FUNCTION(kafka)
 {
@@ -90,8 +98,7 @@ PHP_METHOD(Kafka, set_partition)
         ||
             Z_TYPE_P(partition) != IS_LONG
     ) {
-        //TODO: trigger error or throw exception here!
-        RETURN_FALSE;
+        zend_throw_exception(BASE_EXCEPTION, "Partition is expected to be an int", 0 TSRMLS_CC);
         return;
     }
     kafka_set_partition(Z_LVAL_P(partition));

--- a/php_kafka.h
+++ b/php_kafka.h
@@ -35,6 +35,7 @@ static PHP_METHOD(Kafka, __construct);
 static PHP_METHOD(Kafka, __destruct);
 static PHP_METHOD(Kafka, set_partition);
 static PHP_METHOD(Kafka, setPartition);
+static PHP_METHOD(Kafka, isConnected);
 static PHP_METHOD(Kafka, disconnect);
 static PHP_METHOD(Kafka, produce);
 static PHP_METHOD(Kafka, consume);

--- a/php_kafka.h
+++ b/php_kafka.h
@@ -36,6 +36,7 @@ static PHP_METHOD(Kafka, __construct);
 static PHP_METHOD(Kafka, __destruct);
 static PHP_METHOD(Kafka, set_partition);
 static PHP_METHOD(Kafka, setPartition);
+static PHP_METHOD(Kafka, getPartitionsForTopic);
 static PHP_METHOD(Kafka, isConnected);
 static PHP_METHOD(Kafka, disconnect);
 static PHP_METHOD(Kafka, produce);

--- a/php_kafka.h
+++ b/php_kafka.h
@@ -32,6 +32,7 @@ PHP_RSHUTDOWN_FUNCTION(kafka);
 
 /* Kafka class */
 static PHP_METHOD(Kafka, __construct);
+static PHP_METHOD(Kafka, __destruct);
 static PHP_METHOD(Kafka, set_partition);
 static PHP_METHOD(Kafka, produce);
 static PHP_METHOD(Kafka, consume);

--- a/php_kafka.h
+++ b/php_kafka.h
@@ -18,7 +18,8 @@
 
 #define PHP_KAFKA_VERSION "0.1.0-dev"
 #define PHP_KAFKA_EXTNAME "kafka"
-
+#define PHP_KAFKA_OFFSET_BEGIN "beginning"
+#define PHP_KAFKA_OFFSET_END "end"
 extern zend_module_entry kafka_module_entry;
 
 PHP_MSHUTDOWN_FUNCTION(kafka);

--- a/php_kafka.h
+++ b/php_kafka.h
@@ -34,6 +34,8 @@ PHP_RSHUTDOWN_FUNCTION(kafka);
 static PHP_METHOD(Kafka, __construct);
 static PHP_METHOD(Kafka, __destruct);
 static PHP_METHOD(Kafka, set_partition);
+static PHP_METHOD(Kafka, setPartition);
+static PHP_METHOD(Kafka, disconnect);
 static PHP_METHOD(Kafka, produce);
 static PHP_METHOD(Kafka, consume);
 PHPAPI void kafka_connect(char *brokers);

--- a/stub/kafka.class.php
+++ b/stub/kafka.class.php
@@ -1,0 +1,94 @@
+<?php
+
+final class Kafka
+{
+    const OFFSET_BEGIN = 'beginning';
+    const OFFSET_END = 'end';
+
+    /**
+     * This property does not exist, connection status
+     * Is obtained directly from C kafka client
+     * @var bool
+     */
+    private $connected = false;
+
+    /**
+     * @var int
+     */
+    private $partition = 0;
+
+    public function __construct($brokers = 'localhost:9092')
+    {};
+
+    /**
+     * @param int $partition
+     * @deprecated use setPartition instead
+     */
+    public function set_partition($partition)
+    {
+        $this->partition = $partition;
+    }
+
+    /**
+     * @param int $partition
+     */
+    public function setPartition($partition)
+    {
+        $this->partition = $partition;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isConnected()
+    {
+        return $this->connected;
+    }
+
+    /**
+     * produce message on topic
+     * @param string $topic
+     * @param string $message
+     * @return bool|int
+     */ 
+    public function produce($topic, $message)
+    {
+        $this->connected = true;
+        //internal call, produce message on topic
+        if ($this->partition < 0) {
+            return false;//produce failed
+        }
+        return $this->partition;
+    }
+
+    /**
+     * @param string $topic
+     * @param string|int $offset
+     * @param string|int $count
+     * @return array
+     */
+    public function consume($topic, $offset = self::OFFSET_BEGIN, $count = self::OFFSET_END)
+    {
+        $this->connected = true;
+        $return = [];
+        if (!is_numeric($offset)) {
+            //0 or last message (whatever its offset might be)
+            $start = $offset == self::OFFSET_BEGIN ? 0 : 100;
+        } else {
+            $start = $offset;
+        }
+        if (!is_numeric($count)) {
+            //depending on amount of messages in topic
+            $count = 100;
+        }
+        return array_fill_keys(
+            range($start, $start + $count),
+            'the message at the offset $key'
+        );
+    }
+
+    public function __destruct()
+    {
+        $this->connected = false;
+    }
+}


### PR DESCRIPTION
- Added a partition property to the Kafka class
- Set partition when `Kafka::consume` is called without calling `set_partition` first
- Fixed format string used to write to syslog (%d of `int64_t` -> `PRId64`, %d for `char *offset` -> `%s`)
- Updated the READEME.md
- Check argument value passed to `Kafka::set_partition` -> throws exception in case of an invalid argument
- Reduce wait in `kafka_destroy` to 10ms
- Add checks to return value of `msg_consume`, only adding actual messages to `return_value`
- Add destructor, so as to not postpone `rd_kafka_Destroy` needlessly

Possible follow-up PR:
- add `connect` and `disconnect` methods, perhaps allowing users to specify the wait in MS
- Add beginning and end offset constants
- Deprecate the `set_partition` method, and replace it with a more PSR-compliant `setPartition` method (camel-cased methods are preferred 21 to 1 -> http://www.php-fig.org/psr/psr-2/)
